### PR TITLE
Removed condition for subgenes [Do not merge yet]

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gggenes
 Title: Draw Gene Arrow Maps in 'ggplot2'
-Version: 0.4.0
+Version: 0.4.1
 Authors@R: c(person("David", "Wilkins", email = "david@wilkox.org",
                   role = c("aut", "cre")),
              person("Zachary", "Kurtz", email = "zdkurtz@gmail.com",
@@ -16,7 +16,7 @@ Imports:
     rlang (>= 0.2.0)
 License: GPL-2
 LazyData: true
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.0
 URL: https://wilkox.org/gggenes
 BugReports: https://github.com/wilkox/gggenes/issues
 Suggests: testthat,

--- a/R/geom_subgene_arrow.R
+++ b/R/geom_subgene_arrow.R
@@ -156,12 +156,6 @@ makeContent.subgenearrowtree <- function(x) {
     # Check if subgene is consistent with gene boundaries
     upper <- ifelse(orientbool, x$orig_data$xmin[i], x$orig_data$xmax[i])
     lower <- ifelse(orientbool, x$orig_data$xmax[i], x$orig_data$xmin[i])
-    if (any(x$orig_data[i,c("xsubmin", "xsubmax")] < upper) ||
-        any(x$orig_data[i,c("xsubmin", "xsubmax")] > lower) ||
-        orientbool != (subgene$xsubmax > subgene$xsubmin)
-      ) {
-        return(NULL)
-    }
 
     # Arrowhead defaults to 4 mm, unless the subgene is shorter in which case the
     # subgene is 100% arrowhead

--- a/man/example_genes.Rd
+++ b/man/example_genes.Rd
@@ -5,7 +5,8 @@
 \alias{example_genes}
 \alias{example_subgenes}
 \title{A set of example genes.}
-\format{A data frame with 118 rows and four variables:
+\format{
+A data frame with 118 rows and four variables:
 \describe{
 \item{molecule}{the genome}
 \item{gene}{the name of the gene}
@@ -19,7 +20,10 @@ example_subgenes (237 rows) also contains:
 \item{subgeme}{the name of the subgene}
 \item{from}{the start position of the subgene segment}
 \item{strand}{the end position of the subgene segment}
-}}
+}
+
+An object of class \code{data.frame} with 143 rows and 8 columns.
+}
 \usage{
 example_genes
 

--- a/man/geom_gene_arrow.Rd
+++ b/man/geom_gene_arrow.Rd
@@ -4,11 +4,19 @@
 \alias{geom_gene_arrow}
 \title{A 'ggplot2' geom to draw genes as arrows}
 \usage{
-geom_gene_arrow(mapping = NULL, data = NULL, stat = "identity",
-  position = "identity", na.rm = FALSE, show.legend = NA,
-  inherit.aes = TRUE, arrowhead_width = grid::unit(4, "mm"),
+geom_gene_arrow(
+  mapping = NULL,
+  data = NULL,
+  stat = "identity",
+  position = "identity",
+  na.rm = FALSE,
+  show.legend = NA,
+  inherit.aes = TRUE,
+  arrowhead_width = grid::unit(4, "mm"),
   arrowhead_height = grid::unit(4, "mm"),
-  arrow_body_height = grid::unit(3, "mm"), ...)
+  arrow_body_height = grid::unit(3, "mm"),
+  ...
+)
 }
 \arguments{
 \item{mapping, data, stat, position, na.rm, show.legend, inherit.aes, ...}{As

--- a/man/geom_gene_label.Rd
+++ b/man/geom_gene_label.Rd
@@ -4,12 +4,23 @@
 \alias{geom_gene_label}
 \title{A 'ggplot2' geom to add text labels to gene arrows}
 \usage{
-geom_gene_label(mapping = NULL, data = NULL, stat = "identity",
-  position = "identity", na.rm = FALSE, show.legend = FALSE,
-  inherit.aes = TRUE, padding.x = grid::unit(1, "mm"),
-  padding.y = grid::unit(0.1, "lines"), align = "centre",
-  min.size = 4, grow = F, reflow = F, height = grid::unit(3, "mm"),
-  ...)
+geom_gene_label(
+  mapping = NULL,
+  data = NULL,
+  stat = "identity",
+  position = "identity",
+  na.rm = FALSE,
+  show.legend = FALSE,
+  inherit.aes = TRUE,
+  padding.x = grid::unit(1, "mm"),
+  padding.y = grid::unit(0.1, "lines"),
+  align = "centre",
+  min.size = 4,
+  grow = F,
+  reflow = F,
+  height = grid::unit(3, "mm"),
+  ...
+)
 }
 \arguments{
 \item{mapping, data, stat, position, na.rm, show.legend, inherit.aes, ...}{Standard

--- a/man/geom_subgene_arrow.Rd
+++ b/man/geom_subgene_arrow.Rd
@@ -4,11 +4,19 @@
 \alias{geom_subgene_arrow}
 \title{A 'ggplot2' geom to draw subgene segments of gene arrows}
 \usage{
-geom_subgene_arrow(mapping = NULL, data = NULL, stat = "identity",
-  position = "identity", na.rm = FALSE, show.legend = NA,
-  inherit.aes = TRUE, arrowhead_width = grid::unit(4, "mm"),
+geom_subgene_arrow(
+  mapping = NULL,
+  data = NULL,
+  stat = "identity",
+  position = "identity",
+  na.rm = FALSE,
+  show.legend = NA,
+  inherit.aes = TRUE,
+  arrowhead_width = grid::unit(4, "mm"),
   arrowhead_height = grid::unit(4, "mm"),
-  arrow_body_height = grid::unit(3, "mm"), ...)
+  arrow_body_height = grid::unit(3, "mm"),
+  ...
+)
 }
 \arguments{
 \item{mapping, data, stat, position, na.rm, show.legend, inherit.aes, ...}{As

--- a/man/geom_subgene_label.Rd
+++ b/man/geom_subgene_label.Rd
@@ -4,12 +4,23 @@
 \alias{geom_subgene_label}
 \title{A 'ggplot2' geom to add text labels to subgenes}
 \usage{
-geom_subgene_label(mapping = NULL, data = NULL, stat = "identity",
-  position = "identity", na.rm = FALSE, show.legend = FALSE,
-  inherit.aes = TRUE, padding.x = grid::unit(1, "mm"),
-  padding.y = grid::unit(0.1, "lines"), align = "centre",
-  min.size = 4, grow = F, reflow = F, height = grid::unit(3, "mm"),
-  ...)
+geom_subgene_label(
+  mapping = NULL,
+  data = NULL,
+  stat = "identity",
+  position = "identity",
+  na.rm = FALSE,
+  show.legend = FALSE,
+  inherit.aes = TRUE,
+  padding.x = grid::unit(1, "mm"),
+  padding.y = grid::unit(0.1, "lines"),
+  align = "centre",
+  min.size = 4,
+  grow = F,
+  reflow = F,
+  height = grid::unit(3, "mm"),
+  ...
+)
 }
 \arguments{
 \item{mapping, data, stat, position, na.rm, show.legend, inherit.aes, ...}{Standard

--- a/man/gggenes.Rd
+++ b/man/gggenes.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{gggenes}
 \alias{gggenes}
-\alias{gggenes-package}
 \title{'gggenes': provides a 'ggplot2' geom and helper functions for drawing gene
 arrow maps.}
 \description{

--- a/tests/testthat/test-geom_subgene_arrow.R
+++ b/tests/testthat/test-geom_subgene_arrow.R
@@ -25,22 +25,3 @@ test_that("a simple geom_subgene_arrow plot is drawn without errors", {
   } )
 })
 
-test_that("boundary breaking subgenes are caught", {
-  ## only 1 valid subgene
-  genes <- data.frame(
-    gene = c("cds1", "cd2", "cd3", "cds4"),
-    start = c(2000, 2000, 2050, 2050),
-    end = c(1000, 1000, 3000, 3000),
-    subgenestart =  c(1200, 1000, 2000, 2800),
-    subgeneend = c(1000, 600, 2200, 3200))
-
-    expect_warning(
-      print(plt <- ggplot(genes, aes(xmin = start, xmax = end, y = "strand")) +
-                        geom_gene_arrow() +
-                        geom_subgene_arrow(aes(xsubmin = subgenestart,
-                                       xsubmax = subgeneend), fill = "blue")),
-      regex="Subgene 2.*Subgene 3.*Subgene 4"
-    )
-
-    expect_is(plt, "ggplot")
-})


### PR DESCRIPTION
This PR is a quick solve of issue #21. 
I deleted a few lines in R/geom_subgene_arrow.R and the associated test. I rerun the vignette and all the other plots appear to be fine. I do not know if my change breaks something else. 
This is the hard way. A soft way can be allowed the plotting with a warning for "break gene boundaries".

There are 5 errors in package test:

```
[ OK: 8 | SKIPPED: 0 | WARNINGS: 0 | FAILED: 5 ]
1. Failure: plots look the way they should (@test-plots.R#13)
2. Failure: plots look the way they should (@test-plots.R#21)
3. Failure: plots look the way they should (@test-plots.R#36)
4. Failure: plots look the way they should (@test-plots.R#49)
5. Failure: plots look the way they should (@test-plots.R#58)
```
Honestly, I do not know why. They seem the same to me.

``` r
library(ggplot2)
library(gggenes)

my <- data.frame(virus = c(rep("Example", 4), rep("Example2", 4)),
             ORF = rep(c("ORF1", "ORF2", "ORF2", "ORF3"), 2),
             start = rep(c(43, 150, 150, 250), 2),
             end = rep(c(146, 204, 204, 319), 2),
             strand = c("forward", "forward", "forward", "forward",
                        "forward", "forward", "forward", "reverse"),
             subgene= rep(c("RdRp", "Met", "Hel", "Unknown"), 2),
             from = rep(c(43, 155, 180, 250), 2),
             to = rep(c(146, 175, 204, 300), 2),
             direction = c(1, 1, 1, 1, 
                           1, 1, 1, -1))

ggplot(my, aes(xmin = start, xmax = end, y = virus, label = subgene,
               forward = direction)) +
    # facet_wrap(~ virus, scales = "free", ncol = 1) +
    geom_gene_arrow(fill = "white") +
    geom_subgene_arrow(data = my,
                       aes(xmin = start, xmax = end, y = virus, fill = subgene,
                           xsubmin = from, xsubmax = to, forward = direction), color="black", alpha=.7) +
    geom_subgene_label(aes(xsubmin = from, xsubmax = to)) +
    theme_genes()
```

![](https://i.imgur.com/ixg5w86.png)

<sup>Created on 2020-04-16 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>