### PR TITLE
Addressing closed issue #18 with dummy gene alignment

### DIFF
--- a/R/make_alignment_dummies.R
+++ b/R/make_alignment_dummies.R
@@ -56,7 +56,7 @@ make_alignment_dummies <- function(data, mapping, on, side = "left") {
   dummies <- do.call("rbind", dummies)
 
   # Get alignment edge of target gene (start if side is left, end if right)
-  dummies <- dummies[dummies$id == on, ]
+  dummies <- dummies[which(dummies$id == on), ]
   dummies$true_min <- ifelse(dummies$xmin < dummies$xmax, dummies$xmin, dummies$xmax)
   dummies$true_max <- ifelse(dummies$xmin > dummies$xmax, dummies$xmin, dummies$xmax)
   dummies <- dummies[, c("id", "y", "range_min", "range_max",
@@ -67,12 +67,11 @@ make_alignment_dummies <- function(data, mapping, on, side = "left") {
   dummies$target_offset <- dummies$target_edge - dummies$range_min
 
   # Position start dummy
-  dummies$start_dummy <- dummies$range_min - (max(dummies$target_offset) -
-                                              dummies$target_offset)
+  dummies$start_dummy <- dummies$range_min - (max(dummies$target_offset, na.rm = TRUE) - dummies$target_offset)
 
   # Position end dummy
   dummies$range <- dummies$range_max - dummies$start_dummy
-  dummies$end_dummy <- dummies$range_max + (max(dummies$range) - dummies$range)
+  dummies$end_dummy <- dummies$range_max + (max(dummies$range, na.rm = TRUE) - dummies$range)
 
   # Clean up
   dummies <- dummies[, c("y", "start_dummy", "end_dummy", "id")]


### PR DESCRIPTION
When using "make_alignment_dummies()", Input dataframes containing NAs in the "id" column will be returned with NAs for the dummy dataframe. To amend this, which() was added to line 59. Additionally, na.rm=TRUE was added within max() for lines 70 and 74.